### PR TITLE
Enable alert signals.

### DIFF
--- a/examples/fault_model.json
+++ b/examples/fault_model.json
@@ -1,40 +1,70 @@
 {
-  "fimodels": {
-    "rnd_ctr": {
-      "simultaneous_faults": 2,
-      "stages" : {
-          "stage_1": {
-              "input": "$auto$simplemap.cc:527:simplemap_adff_sdff$14916",
-              "output": "$auto$simplemap.cc:527:simplemap_adff_sdff$14916",
-              "type": "input"
+    "fimodels": {
+      "rnd_ctr": {
+        "simultaneous_faults": 2,
+        "stages" : {
+            "stage_1": {
+                "input": "$auto$simplemap.cc:527:simplemap_adff_sdff$14916",
+                "output": "$auto$simplemap.cc:527:simplemap_adff_sdff$14916",
+                "type": "input"
+            },
+            "stage_2": {
+                "input": "$auto$simplemap.cc:559:simplemap_adffe_sdffe_sdffce$14209",
+                "output": "$auto$simplemap.cc:559:simplemap_adffe_sdffe_sdffce$14209",
+                "type": "input"
+            },
+            "stage_3": {
+                "input": "$auto$simplemap.cc:527:simplemap_adff_sdff$14916",
+                "output": "rnd_ctr_err_sum(1)",
+                "type": "output"
+            },
+            "stage_4": {
+                "input": "$auto$simplemap.cc:527:simplemap_adff_sdff$14916",
+                "output": "key_expand_round_o(4)_75",
+                "type": "output"
+            }
+        },
+        "node_fault_mapping": {
+            "NAND2_X1": [ "NOR2_X1", "OR2_X1", "XOR2_X1"],
+            "NAND3_X1": ["NOR3_X1", "AND3_X1", "OR3_X1"],
+            "AND3_X1": ["NOR3_X1", "NAND3_X1", "OR3_X1"],
+            "OR3_X1": ["NOR3_X1", "NAND3_X1", "AND3_X1"],
+            "NOR2_X1":  [ "NAND2_X1", "OR2_X1", "XOR2_X1"],
+            "AND2_X1": [ "NAND2_X1", "NOR2_X1", "XOR2_X1"],
+            "XOR2_X1": [ "NAND2_X1", "NOR2_X1", "OR2_X1"],
+            "XNOR2_X1": ["XOR2_X1", "NAND2_X1", "NOR2_X1" ],
+            "INV_X1": ["INV_X1"],
+            "AOI21_X1": ["OAI21_X1"],
+            "OAI21_X1": ["AOI21_X1"],
+            "OAI22_X1": ["AOI22_X1"],
+            "AOI22_X1": ["OAI22_X1"]
           },
-          "stage_2": {
-            "input": "$auto$simplemap.cc:527:simplemap_adff_sdff$14916",
-            "output": "rnd_ctr_err_sum(1)",
-            "type": "output"
+        "fault_locations": {
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16797": "stage_1",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16798": "stage_1",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16799": "stage_1",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16931": "stage_2",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16933": "stage_2",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16934": "stage_2",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16772": "stage_3",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16778": "stage_3",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16774": "stage_3",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16777": "stage_3",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16780": "stage_3",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16773": "stage_3",
+          "$abc$16613$auto$blifparse.cc:381:parse_blif$16779": "stage_3"
+        },
+        "output_values": {
+          "key_expand_round_o(4)_75": 0
+        },
+        "input_values": {
+            "$auto$simplemap.cc:527:simplemap_adff_sdff$14916": 1,
+            "$auto$simplemap.cc:559:simplemap_adffe_sdffe_sdffce$14209": 1
+        },
+        "alert_values": 
+        {
+            "rnd_ctr_err_sum(1)": 0
         }
-      },
-      "node_fault_mapping": {
-        "NAND2_X1": [ "NOR2_X1", "OR2_X1", "XOR2_X1"],
-        "NOR2_X1":  [ "NAND2_X1", "OR2_X1", "XOR2_X1"],
-        "AND2_X1": [ "NAND2_X1", "NOR2_X1", "XOR2_X1"],
-        "XOR2_X1": [ "NAND2_X1", "NOR2_X1", "OR2_X1"],
-        "XNOR2_X1": ["XOR2_X1", "NAND2_X1", "NOR2_X1" ],
-        "INV_X1": ["INV_X1"]
-
-      },
-      "fault_locations": {
-        "$abc$16613$auto$blifparse.cc:381:parse_blif$16783": "stage_1",
-        "$abc$16613$auto$blifparse.cc:381:parse_blif$16770": "stage_2",
-        "$abc$16613$auto$blifparse.cc:381:parse_blif$16797": "stage_1",
-        "$abc$16613$auto$blifparse.cc:381:parse_blif$16634": "stage_2"
-      },
-      "output_values": {
-        "rnd_ctr_err_sum(1)": 0
-      },
-      "input_values": {
-          "$auto$simplemap.cc:527:simplemap_adff_sdff$14916": 1
       }
     }
-  }
- }
+   }

--- a/fi_injector.py
+++ b/fi_injector.py
@@ -243,6 +243,9 @@ def set_in_out_nodes(graph: nx.DiGraph, node_in: str, node_out: str,
     for output_node in fi_model["output_values"]:
         output_nodes.append(output_node)
 
+    for output_node in fi_model["alert_values"]:
+        output_nodes.append(output_node)
+
     for input_node in fi_model["input_values"]:
         input_nodes.append(input_node)
 
@@ -509,7 +512,7 @@ def handle_fault_model(graph: nx.DiGraph, fi_model_name: str,
 
 def main():
     tstp_begin = time.time()
-    ray.init()
+    ray.init(num_cpus=16)
     args = parse_arguments()
 
     # Open the fault model and the graph.

--- a/helpers.py
+++ b/helpers.py
@@ -8,10 +8,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-import cell_library
 import networkx as nx
 import numpy as np
 import pkg_resources
+
+import cell_library
 
 """Part of the fault injection framework for the OpenTitan.
 

--- a/injector_class.py
+++ b/injector_class.py
@@ -5,13 +5,13 @@
 import copy
 from typing import Tuple
 
-import cell_library
 import networkx as nx
 import ray
-from formula_class import FormulaBuilder
 from sympy.logic.inference import satisfiable
 
+import cell_library
 import helpers
+from formula_class import FormulaBuilder
 from helpers import Node
 
 
@@ -86,32 +86,21 @@ class FiInjector:
 
         return faulty_graph
 
-    def _create_diff_graph(self, faulty_graph):
-        """ Create the differential graph based on the faulty graph. 
+    def _add_in_logic(self, diff_graph):
+        """ Add the input logic to the differential graph. 
 
-        This function creates the differential graph by merging the faulty graph
-        and the unmodified target graph into a common graph. The inputs of the 
-        differential graph are set to predefined values specified in the fault
-        model. The output is compared to a predefined value using a XNOR. To
-        get a single output port, the output of the XNORs are connected using a
-        AND.
+        In the input logic, the input nodes defined in the fault model are 
+        connected with their predefined value.
 
         Args:
-            faulty_graph: The target graph with the faulty nodes.
+            diff_graph: The differential graph.
         
         Returns:
-            The differential graph.
+            The differential graph with the input nodes.
         """
-        orig_graph = copy.deepcopy(self.target_graph)
-        faulty_graph_renamed = copy.deepcopy(faulty_graph)
-        # Rename the faulty graph.
-        faulty_graph_renamed = helpers.rename_nodes(faulty_graph_renamed,
-                                                    "_faulty", True)
-        # Merge the graphs into a common graph.
-        diff_graph = nx.compose(orig_graph, faulty_graph_renamed)
 
-        # Add the input logic. Here, the values are set to a defined value.
         diff_graph_in_logic = copy.deepcopy(diff_graph)
+        # Add the null and one node for the predefined values.
         diff_graph_in_logic.add_node(
             "null", **{
                 "node":
@@ -122,6 +111,8 @@ class FiInjector:
                 "node": Node("one", "one", "one_node", {}, {'1': "O"}, "",
                              "black")
             })
+        # Get the input values from the fault model and connect each input node
+        # with the null / one node.
         input_values = self.fault_model["input_values"]
         for node, value in input_values.items():
             # Find all input nodes and connect with node.
@@ -143,22 +134,39 @@ class FiInjector:
                                                  name="null_wire",
                                                  out_pin="O",
                                                  in_pin="I1")
+        return diff_graph_in_logic
 
-        # Add the output logic. The output logic compares the result with the
-        # expected result stored in "output_values" of the fault model.
-        diff_graph_out_logic = copy.deepcopy(diff_graph_in_logic)
-        output_values = self.fault_model["output_values"]
+    def _add_xor_xnor(self, diff_graph_out_logic, diff_graph, values, alert):
+        """ Add the XORs and XNORs for the output logic to the graph. 
+
+        Args:
+            diff_graph_out_logic: The differential graph with the output logic.
+            diff_graph: The differential graph
+            values: The values for the selected nodes.
+            alert: 
+        
+        Returns:
+            The differential graph with the XORs and XNORs.
+        """
         out_nodes_added = []
-        for node, value in output_values.items():
-            # Add XNOR node for each output node and connect with this port.
+
+        for node_target, value in values.items():
+            # Add XNOR/XOR node for each output node and connect with this port.
             nodes = [
-                n for n, d in diff_graph.nodes(data=True) if
-                (d["node"].parent_name == node and d["node"].type == "output")
+                n for n, d in diff_graph.nodes(data=True)
+                if (d["node"].parent_name == node_target
+                    and d["node"].type == "output")
             ]
             for node in nodes:
                 if "_faulty" in node:
-                    node_name = node + "_xor"
-                    node_type = "xor"
+                    if alert:
+                        # For the alert signals, use XNORs.
+                        node_name = node + "_xnor"
+                        node_type = "xnor"
+                    else:
+                        # For outputs use XORs.
+                        node_name = node + "_xor"
+                        node_type = "xor"
                 else:
                     node_name = node + "_xnor"
                     node_type = "xnor"
@@ -188,7 +196,45 @@ class FiInjector:
                                               in_pin="I2")
                 diff_graph_out_logic.nodes[node]["node"].outputs = {0: "O"}
                 diff_graph_out_logic.nodes[node]["node"].inputs = {0: "I"}
-        # Connect the outputs of the XNORs with a AND.
+        return out_nodes_added
+
+    def _add_out_logic(self, diff_graph):
+        """ Add the output logic to the differential graph. 
+        
+        For the non-faulty graph in the differential graph:
+        -XNORs are used to compare the output to the expected output.
+        For the faulty graph in the differential graph:
+        -XORs are used to compare the output to the expected output.
+        -XNORs are used to compare the alert signals to the expected 
+         alert output signals. We are using XNORs as we are only interested in
+         faults manipulating the output but not the alert signal.
+
+        All XNORs/XORs are ANDed to produce the final circuit.
+
+        Args:
+            diff_graph: The differential graph.
+        
+        Returns:
+            The differential graph with the output logic.
+        """
+        diff_graph_out_logic = copy.deepcopy(diff_graph)
+        output_values = self.fault_model["output_values"]
+        alert_values = self.fault_model["alert_values"]
+        out_nodes_added = []
+        # Add the output logic for the output values.
+        out_nodes_added.append(
+            self._add_xor_xnor(diff_graph_out_logic, diff_graph, output_values,
+                               False))
+        # Add the output logic for the alert values.
+        out_nodes_added.append(
+            self._add_xor_xnor(diff_graph_out_logic, diff_graph, alert_values,
+                               True))
+        # Flatten the list.
+        out_nodes_added = [
+            item for sublist in out_nodes_added for item in sublist
+        ]
+
+        # Connect the outputs of the XNOR/XORs with a AND.
         out_name = "output_logic_and"
         diff_graph_out_logic.add_node(
             out_name, **{
@@ -207,6 +253,39 @@ class FiInjector:
 
         return diff_graph_out_logic
 
+    def _create_diff_graph(self, faulty_graph):
+        """ Create the differential graph based on the faulty graph. 
+
+        This function creates the differential graph by merging the faulty graph
+        and the unmodified target graph into a common graph. The inputs of the 
+        differential graph are set to predefined values specified in the fault
+        model. The output is compared to a predefined value using a XNOR. To
+        get a single output port, the output of the XNORs are connected using a
+        AND.
+
+        Args:
+            faulty_graph: The target graph with the faulty nodes.
+        
+        Returns:
+            The differential graph.
+        """
+        orig_graph = copy.deepcopy(self.target_graph)
+        faulty_graph_renamed = copy.deepcopy(faulty_graph)
+        # Rename the faulty graph.
+        faulty_graph_renamed = helpers.rename_nodes(faulty_graph_renamed,
+                                                    "_faulty", True)
+        # Merge the graphs into a common graph.
+        diff_graph = nx.compose(orig_graph, faulty_graph_renamed)
+
+        # Add the input logic. Here, the values are set to a defined value.
+        diff_graph_in_logic = self._add_in_logic(diff_graph)
+
+        # Add the output logic. The output logic compares the result with the
+        # expected result stored in "output_values" of the fault model.
+        diff_graph_out_logic = self._add_out_logic(diff_graph_in_logic)
+
+        return diff_graph_out_logic
+
     def perform_attack(self) -> Tuple[str, bool, list]:
         """ Perform the attack. 
 
@@ -218,7 +297,6 @@ class FiInjector:
         Returns:
             The result of the attack.
         """
-
         # Inject the faults into the target graph.
         faulty_graph = self._inject_faults()
 


### PR DESCRIPTION
This PR extends the fault model to include alert signals. These signals are driven by the fault countermeasure and are set, when a fault is detected.

As we want to find effective faults (i.e., an output signal does not match the expected value **and** the alert signal of the fault countermeasure is not triggered), the output logic of the differential graph was adapted in this PR. For these signals, a XNOR is used to compare the alert signal to the expected signal.

Signed-off-by: Pascal Nasahl <nasahl@google.com>