### PR TITLE
Autogenerate fault locations.

### DIFF
--- a/examples/fault_model.json
+++ b/examples/fault_model.json
@@ -32,13 +32,18 @@
             "NOR2_X1":  [ "NAND2_X1", "OR2_X1", "XOR2_X1"],
             "AND2_X1": [ "NAND2_X1", "NOR2_X1", "XOR2_X1"],
             "XOR2_X1": [ "NAND2_X1", "NOR2_X1", "OR2_X1"],
-            "XNOR2_X1": ["XOR2_X1", "NAND2_X1", "NOR2_X1" ],
+            "XNOR2_X1": ["XOR2_X1", "NAND2_X1", "NOR2_X1"],
             "INV_X1": ["INV_X1"],
             "AOI21_X1": ["OAI21_X1"],
             "OAI21_X1": ["AOI21_X1"],
             "OAI22_X1": ["AOI22_X1"],
-            "AOI22_X1": ["OAI22_X1"]
-          },
+            "AOI22_X1": ["OAI22_X1"],
+            "OAI211_X1": ["AOI211_X1"],
+            "AOI211_X1": ["OAI211_X1"],
+            "NOR4_X1": ["OR4_X1", "NAND4_X1"],
+            "OR4_X1": ["NOR4_X1", "NAND4_X1"],
+            "NAND4_X1": ["OR4_X1", "NOR4_X1"]
+        },
         "fault_locations": {
           "$abc$16613$auto$blifparse.cc:381:parse_blif$16797": "stage_1",
           "$abc$16613$auto$blifparse.cc:381:parse_blif$16798": "stage_1",


### PR DESCRIPTION
The "auto_fl" command line argument now allows to automatically create the
fault locations. For this, all comb. gates of the target circuit are
extracted and are used for the FI injection.

Hence, there is now no need to manually define the fault locations in
the fault_model.json file.

Signed-off-by: Pascal Nasahl <nasahl@google.com>