### PR TITLE
Move handling of zero/one nodes to formula_class.

### DIFF
--- a/cell_lib_nangate45_autogen.py
+++ b/cell_lib_nangate45_autogen.py
@@ -641,12 +641,7 @@ def validate_inputs(inputs: dict, graph: nx.DiGraph, type: str) -> dict:
     if expected_inputs <= inputs.keys():
         input_symbols = {}
         for input_pin, input in inputs.items():
-            if graph.nodes[input.node]['node'].type == 'null_node':
-                input_symbols[input_pin] = zero
-            elif graph.nodes[input.node]['node'].type == 'one_node':
-                input_symbols[input_pin] = one
-            else:
-                input_symbols[input_pin] = input.name
+            input_symbols[input_pin] = input.name
 
         return input_symbols
     else:

--- a/formula_class.py
+++ b/formula_class.py
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import DefaultDict
 
 from sympy import Symbol
-from typing import DefaultDict
 
 import helpers
 from helpers import InputPin
 
 logger = logging.getLogger(__name__)
+
 
 class FormulaBuilder:
     """ Class for converting a graph into a boolean formula.
@@ -73,10 +74,17 @@ class FormulaBuilder:
                         # Assemble the name of the input pin of the current node
                         # and translate the name to an integer value.
                         input_name = in_node + "_" + out_pin
-                        if input_name not in node_int:
-                            node_int[input_name] = node_int_cntr
-                            node_int_cntr += 1
-                        inputs[in_pin] = InputPin(node, node_int[input_name])
+                        in_node_type = self.graph.nodes[in_node]["node"].type
+                        if in_node_type == "null_node":
+                            inputs[in_pin] = InputPin(node, self.cell_lib.zero)
+                        elif in_node_type == "one_node":
+                            inputs[in_pin] = InputPin(node, self.cell_lib.one)
+                        else:
+                            if input_name not in node_int:
+                                node_int[input_name] = node_int_cntr
+                                node_int_cntr += 1
+                            inputs[in_pin] = InputPin(node,
+                                                      node_int[input_name])
 
                     # If there is an input port with input size greater than 1
                     # than we have a predefined input value of one/zero for this

--- a/template/cell_lib.py.tpl
+++ b/template/cell_lib.py.tpl
@@ -175,12 +175,7 @@ def validate_inputs(inputs: dict, graph: nx.DiGraph, type: str) -> dict:
     if expected_inputs <= inputs.keys():
         input_symbols = {}
         for input_pin, input in inputs.items():
-            if graph.nodes[input.node]['node'].type == 'null_node':
-                input_symbols[input_pin] = zero
-            elif graph.nodes[input.node]['node'].type == 'one_node':
-                input_symbols[input_pin] = one
-            else:
-                input_symbols[input_pin] = input.name
+            input_symbols[input_pin] = input.name
 
         return input_symbols
     else:


### PR DESCRIPTION
In this PR, the handling of zero and one nodes is moved from the cell
lib to the formula class. When detecting an input node of type one_node
or zero_node, the variable name is set to cell_lib.zero/one.

Signed-off-by: Pascal Nasahl <nasahl@google.com>