### PR TITLE
Fix bug in zero/null handling.

### DIFF
--- a/cell_lib_nangate45_autogen.py
+++ b/cell_lib_nangate45_autogen.py
@@ -2807,7 +2807,7 @@ def input_formula_Q(inputs: dict, graph: nx.DiGraph, solver):
 
     p = validate_inputs(inputs, graph, 'input_formula')
 
-    if inputs['I1'].node == 'one':
+    if 'one' in inputs['I1'].node:
         # Input is connected to 1.
         # Return a one.
         solver.add_clause([-one, p['node_name']])
@@ -2832,7 +2832,7 @@ def input_formula_QN(inputs: dict, graph: nx.DiGraph, solver):
 
     p = validate_inputs(inputs, graph, 'input_formula')
 
-    if inputs['I1'].node == 'one':
+    if 'one' in inputs['I1'].node:
         # Input is connected to 1.
         # Return a zero.
         solver.add_clause([-zero, p['node_name']])

--- a/formula_class.py
+++ b/formula_class.py
@@ -79,16 +79,16 @@ class FormulaBuilder:
                                 "node"].type
                             if in_node_type == "null_node":
                                 inputs[in_pin] = InputPin(
-                                    node, self.cell_lib.zero)
+                                    input_name, self.cell_lib.zero)
                             elif in_node_type == "one_node":
                                 inputs[in_pin] = InputPin(
-                                    node, self.cell_lib.one)
+                                    input_name, self.cell_lib.one)
                             else:
                                 if input_name not in node_int:
                                     node_int[input_name] = node_int_cntr
                                     node_int_cntr += 1
                                 inputs[in_pin] = InputPin(
-                                    node, node_int[input_name])
+                                    input_name, node_int[input_name])
 
                     # If there is an input port with input size greater than 1
                     # than we have a predefined input value of one/zero for this

--- a/template/cell_lib.py.tpl
+++ b/template/cell_lib.py.tpl
@@ -546,7 +546,7 @@ def input_formula_Q(inputs: dict, graph: nx.DiGraph, solver):
 
     p = validate_inputs(inputs, graph, 'input_formula')
 
-    if inputs['I1'].node == 'one':
+    if 'one' in inputs['I1'].node:
         # Input is connected to 1.
         # Return a one.
         solver.add_clause([-one, p['node_name']])
@@ -571,7 +571,7 @@ def input_formula_QN(inputs: dict, graph: nx.DiGraph, solver):
 
     p = validate_inputs(inputs, graph, 'input_formula')
 
-    if inputs['I1'].node == 'one':
+    if 'one' in inputs['I1'].node:
         # Input is connected to 1.
         # Return a zero.
         solver.add_clause([-zero, p['node_name']])


### PR DESCRIPTION
The wrong node name was used for creating the formulas for inputs with a
zero or one.

Signed-off-by: Pascal Nasahl <nasahl@google.com>