### PR TITLE
Add possibility to define expected fault outputs.

### DIFF
--- a/examples/fault_model.json
+++ b/examples/fault_model.json
@@ -38,6 +38,10 @@
         "alert_values": 
         {
             "rnd_ctr_err_sum(1)": 0
+        },
+        "output_fault_values": 
+        {
+            
         }
       }
     }

--- a/examples/fault_model_mubi.json
+++ b/examples/fault_model_mubi.json
@@ -100,6 +100,10 @@
         "alert_values": 
         {
             "rnd_ctr_err_sum(1)": 0
+        },
+        "output_fault_values": 
+        {
+            
         }
       }
     }

--- a/examples/fault_model_rnd_cntr.json
+++ b/examples/fault_model_rnd_cntr.json
@@ -106,6 +106,10 @@
         "alert_values": 
         {
             "$abc$16618$auto$blifparse.cc:381:parse_blif$16775": 0
+        },
+        "output_fault_values": 
+        {
+            
         }
       }
     }


### PR DESCRIPTION
When verifying state machines, we want to have the possibility to check,
if we could reach a certain state. In this PR, a new feature allowing to
define expected fault values is added. The framework now tries to find a
fault which changes the output of the circuit to the expected fault
value.

Signed-off-by: Pascal Nasahl <nasahl@google.com>