### PR TITLE
Manual garbage collection.

### DIFF
--- a/injector_class.py
+++ b/injector_class.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-
+import gc
 import networkx as nx
 import ray
 from pysat.solvers import Lingeling
@@ -395,7 +395,13 @@ class FiInjector:
             solver.add_clause([-self.cell_lib.zero])
             # Hand the boolean formula to the SAT solver.
             sat_result = solver.solve()
-
+            # Invoke the garbage collector.
+            del solver
+            del formula_builder
+            del faulty_graph
+            del diff_graph
+            gc.collect()
+            # Append result.
             results.append(
                 FIResult(fault_name=self.fault_name,
                          sat_result=sat_result,


### PR DESCRIPTION
When starting a large number of ray workers, systems tend to run
out-of-memory. Manually calling the GC solves this problem.

Signed-off-by: Pascal Nasahl <nasahl@google.com>