### PR TITLE
Switch to MultiDiGraph.

### DIFF
--- a/examples/fault_model.json
+++ b/examples/fault_model.json
@@ -10,12 +10,12 @@
             },
             "stage_2": {
                 "inputs": ["$auto$simplemap.cc:527:simplemap_adff_sdff$14922"],
-                "outputs": ["rnd_ctr_err_sum(1)"],
+                "outputs": ["rnd_ctr_err_sum"],
                 "type": "output"
             },
             "stage_3": {
                 "inputs": ["$auto$simplemap.cc:527:simplemap_adff_sdff$14922"],
-                "outputs": ["key_expand_round_o(4)_75"],
+                "outputs": ["key_expand_round_o"],
                 "type": "output"
             }
         },
@@ -30,14 +30,26 @@
             "$abc$16637$auto$blifparse.cc:381:parse_blif$16820": ["stage_2"]
         },
         "output_values": {
-          "key_expand_round_o(4)_75": 1
+          "key_expand_round_o": {
+                "O": {
+                    "0": 1
+                }
+          }
         },
         "input_values": {
-            "$auto$simplemap.cc:527:simplemap_adff_sdff$14922": 0
+            "$auto$simplemap.cc:527:simplemap_adff_sdff$14922": {
+                "D": {
+                    "0": 0
+                }
+            }
         },
         "alert_values": 
         {
-            "rnd_ctr_err_sum(1)": 0
+            "rnd_ctr_err_sum": {
+                "O": {
+                    "0": 0
+                }
+            }
         },
         "output_fault_values": 
         {

--- a/formula_class.py
+++ b/formula_class.py
@@ -43,52 +43,53 @@ class FormulaBuilder:
         # The SAT solver uses integers as variable names. A logical 1=1, a
         # logical 0=2. The next gate uses 3 as a variable name.
         node_int_cntr = 3
+        # Loop over all nodes of the target graph.
         for node, node_attribute in self.graph.nodes(data=True):
             node_type = node_attribute["node"].type
-            filter_types = {"null_node", "one_node"}
+            filter_types = {"null_node", "one_node", "output_logic_terminate"}
+            # Ignore null and one nodes as we are handling them in the injector.
             if node_type not in filter_types:
-                # Here we are collecting the input names and the node name.
-                # The node name consists of the node name and the output pin
-                # as we could have multiple output pins for a node.
-                for wire, out_pin in node_attribute["node"].outputs.items():
+                # Loop over output ports of the current node (e.g. Q and QN ports).
+                for out_node_out, out_node_in, out_edge_data in self.graph.out_edges(
+                        node, data=True):
                     inputs = {}
-                    node_type_out = node_type + "_" + out_pin
-                    # Assemble the name of the current node and translate the
-                    # name to an integer value needed by the SAT solver.
-                    node_name = node + "_" + out_pin
+                    port_name = out_edge_data["edge"].out_port
+                    node_type_out = node_type + "_" + port_name
+                    # Assemble the name of the current node
+                    # (=node_name+out_port_name) and translate the name to an
+                    # integer value needed by the SAT solver.
+                    node_name = node + "_" + port_name
                     if node_name not in node_int:
                         node_int[node_name] = node_int_cntr
                         node_int_cntr += 1
                     inputs["node_name"] = InputPin(node, node_int[node_name])
 
-                    # Get the input pins of the current node. As an input pin
-                    # can be connected to a node having multiple outputs (e.g.
-                    # Q or QN), we have to also store the output pin of the
-                    # other edge.
-                    for edge in self.graph.in_edges(node):
-                        in_node = edge[0]
-                        in_pins = self.graph.get_edge_data(edge[0],
-                                                           edge[1])["in_pin"]
-                        out_pin = self.graph.get_edge_data(edge[0],
-                                                           edge[1])["out_pin"]
-                        for in_pin in in_pins:
-                            # Assemble the name of the input pin of the current node
-                            # and translate the name to an integer value.
-                            input_name = in_node + "_" + out_pin
-                            in_node_type = self.graph.nodes[in_node][
-                                "node"].type
-                            if in_node_type == "null_node":
-                                inputs[in_pin] = InputPin(
-                                    input_name, self.cell_lib.zero)
-                            elif in_node_type == "one_node":
-                                inputs[in_pin] = InputPin(
-                                    input_name, self.cell_lib.one)
-                            else:
-                                if input_name not in node_int:
-                                    node_int[input_name] = node_int_cntr
-                                    node_int_cntr += 1
-                                inputs[in_pin] = InputPin(
-                                    input_name, node_int[input_name])
+                    # Loop over all input edges of the current node to find the
+                    # nodes connected to the current node.
+                    for in_node_out, in_node_in, in_edge_data in self.graph.in_edges(
+                            node, data=True):
+                        in_node_type = self.graph.nodes[in_node_out][
+                            "node"].type
+                        # Get the name of the node (=in_node_out+out_port_name)
+                        # connected to the input pin of the current node.
+                        input_name = in_node_out + "_" + in_edge_data[
+                            "edge"].out_port
+                        # Get the name of the input port.
+                        in_port = in_edge_data["edge"].in_port
+                        # Add the name of the node + the in port to the input dict.
+                        # Connect zero/ones with the corresponding element.
+                        if in_node_type == "null_node":
+                            inputs[in_port] = InputPin(input_name,
+                                                       self.cell_lib.zero)
+                        elif in_node_type == "one_node":
+                            inputs[in_port] = InputPin(input_name,
+                                                       self.cell_lib.one)
+                        else:
+                            if input_name not in node_int:
+                                node_int[input_name] = node_int_cntr
+                                node_int_cntr += 1
+                            inputs[in_port] = InputPin(input_name,
+                                                       node_int[input_name])
 
                     # If there is an input port with input size greater than 1
                     # than we have a predefined input value of one/zero for this
@@ -98,6 +99,14 @@ class FormulaBuilder:
                         self.cell_lib.cell_mapping[node_type_out](inputs,
                                                                   self.graph,
                                                                   self.solver)
+                    elif node_type == "in_node":
+                        # As in_nodes can have multiple in/out ports, only
+                        # use the edge connected to the current output port.
+                        inputs_in_node = {}
+                        inputs_in_node["node_name"] = inputs["node_name"]
+                        inputs_in_node[port_name] = inputs[port_name]
+                        self.cell_lib.cell_mapping[node_type_out](
+                            inputs_in_node, self.graph, self.solver)
                     elif node_type != "input":
                         if node_type_out in self.cell_lib.cell_mapping and self.graph.in_edges(
                                 node):

--- a/helpers.py
+++ b/helpers.py
@@ -27,6 +27,51 @@ header = "-" * int(TERMINAL_COLS)
 
 
 @dataclass
+class Connection:
+    node_out: str
+    node_in: int
+    wire: str
+
+
+@dataclass
+class NodePort:
+    type: str
+    name: str
+    pins: list
+
+
+@dataclass
+class NodePin:
+    number: int
+    wire: str
+
+
+@dataclass
+class Edge:
+    in_port: str
+    in_pin: int
+    out_port: str
+    out_pin: int
+    wire: str
+
+
+@dataclass
+class Node:
+    """ Node class.
+
+    A node represents an element (gate, ...) in the circuit.
+
+    """
+    name: str
+    parent_name: str
+    type: str
+    in_ports: list
+    out_ports: list
+    stage: str
+    node_color: str
+
+
+@dataclass
 class InputPin:
     """ InputPin data class.
 
@@ -64,22 +109,6 @@ def show_and_exit(clitool: str, packages: str) -> None:
     for p in packages:
         sys.stderr.write(p + ' ' + pkg_resources.require(p)[0].version + '\n')
     exit(0)
-
-
-@dataclass
-class Node:
-    """ Node class.
-
-    A node represents an element (gate, ...) in the circuit.
-
-    """
-    name: str
-    parent_name: str
-    type: str
-    inputs: dict
-    outputs: dict
-    stage: str
-    node_color: str
 
 
 @dataclass

--- a/template/cell_lib.py.tpl
+++ b/template/cell_lib.py.tpl
@@ -187,6 +187,33 @@ def validate_inputs(inputs: dict, graph: nx.DiGraph, type: str) -> dict:
         raise Exception('Gate ' + type + ' is missing some inputs.')
 
 
+def validate_generic_inputs(inputs: dict, num_inputs: int, type: str) -> dict:
+    """ Validates the provided input of a generic gate.
+
+    Generic gates, such as inputs, have generic input ports. Rename them to
+    input + counter.
+
+    Args:
+        inputs: The list of provided inputs.
+        num_inputs: The number of expected inputs.
+        type: The type of the gate.
+
+    Returns:
+        The inputs for the generic gate.
+    """
+    if len(inputs) != num_inputs:
+        logger.error(inputs)
+        raise Exception('Gate ' + type + ' is missing some inputs.')
+    input_symbols = {}
+    in_count = 0
+    for input_pin, input in inputs.items():
+        if input_pin == "node_name":
+            input_symbols[input_pin] = input.name
+        else:
+            input_symbols["input_" + str(in_count)] = input.name
+            in_count += 1
+    return input_symbols
+
 % for cell_function in cell_lib.cell_formulas:
 def ${cell_function.name}(inputs: dict, graph: nx.DiGraph, solver):
     ''' ${cell_function.name} gate.
@@ -213,36 +240,35 @@ def xnor(inputs: dict, graph: nx.DiGraph, solver):
     """ xnor gate.
 
     Args:
-        inputs: {'I1', 'I2', 'node_name'}.
+        inputs: {'input_0', 'input_1', 'node_name'}.
         graph: The networkx graph of the circuit.
         solver: The SAT solver instance.
 
     Returns:
-        ZN = '!(I1 ^ I2)'.
+        ZN = '!(input_0 ^ input_1)'.
     """
-    p = validate_inputs(inputs, graph, 'xnor')
-    solver.add_clause([-p['I1'], -p['I2'], p['node_name']])
-    solver.add_clause([p['I1'], p['I2'], p['node_name']])
-    solver.add_clause([p['I1'], -p['I2'], -p['node_name']])
-    solver.add_clause([-p['I1'], p['I2'], -p['node_name']])
+    p = validate_generic_inputs(inputs, 3, 'xnor')
+    solver.add_clause([-p['input_0'], -p['input_1'], p['node_name']])
+    solver.add_clause([p['input_0'], p['input_1'], p['node_name']])
+    solver.add_clause([p['input_0'], -p['input_1'], -p['node_name']])
+    solver.add_clause([-p['input_0'], p['input_1'], -p['node_name']])
 
 
 def xor(inputs: dict, graph: nx.DiGraph, solver):
     """ xor gate.
 
     Args:
-        inputs: {'I1', 'I2', 'node_name'}.
+        inputs: {'input_0', 'input_1', 'node_name'}.
         graph: The networkx graph of the circuit.
 
     Returns:
-        ZN = '(I1 ^ I2)'.
+        ZN = '(input_0 ^ input_1)'.
     """
-    p = validate_inputs(inputs, graph, 'xor')
-    solver.add_clause([-p['I1'], -p['I2'], -p['node_name']])
-    solver.add_clause([p['I1'], p['I2'], -p['node_name']])
-    solver.add_clause([p['I1'], -p['I2'], p['node_name']])
-    solver.add_clause([-p['I1'], p['I2'], p['node_name']])
-
+    p = validate_generic_inputs(inputs, 3, 'xor')
+    solver.add_clause([-p['input_0'], -p['input_1'], -p['node_name']])
+    solver.add_clause([p['input_0'], p['input_1'], -p['node_name']])
+    solver.add_clause([p['input_0'], -p['input_1'], p['node_name']])
+    solver.add_clause([-p['input_0'], p['input_1'], p['node_name']])
 
 def and_output(inputs: dict, graph: nx.DiGraph, solver):
     """ and gate.
@@ -541,16 +567,15 @@ def input_formula_Q(inputs: dict, graph: nx.DiGraph, solver):
     """ Sets a input pin to a predefined (0 or 1) value.
 
     Args:
-        inputs: {'I1', 'node_name'}.
+        inputs: {'input_0', 'node_name'}.
         graph: The networkx graph of the circuit.
 
     Returns:
         0 or 1.
     """
+    p = validate_generic_inputs(inputs, 2, "input_formula_Q")
 
-    p = validate_inputs(inputs, graph, 'input_formula')
-
-    if 'one' in inputs['I1'].node:
+    if one == p['input_0']:
         # Input is connected to 1.
         # Return a one.
         solver.add_clause([-one, p['node_name']])
@@ -566,16 +591,15 @@ def input_formula_QN(inputs: dict, graph: nx.DiGraph, solver):
     """ Sets a input pin to a predefined (0 or 1) value.
 
     Args:
-        inputs: {'I1', 'node_name'}.
+        inputs: {'input_0', 'node_name'}.
         graph: The networkx graph of the circuit.
 
     Returns:
         0 or 1.
     """
+    p = validate_generic_inputs(inputs, 2, "input_formula_QN")
 
-    p = validate_inputs(inputs, graph, 'input_formula')
-
-    if 'one' in inputs['I1'].node:
+    if one == p['input_0']:
         # Input is connected to 1.
         # Return a zero.
         solver.add_clause([-zero, p['node_name']])
@@ -584,34 +608,35 @@ def input_formula_QN(inputs: dict, graph: nx.DiGraph, solver):
         # Input ist connected to 0.
         # Return a one.
         solver.add_clause([-one, p['node_name']])
+        solver.add_clause([one, -p['node_name']])
 
 
 def in_node_Q(inputs: dict, graph: nx.DiGraph, solver):
     """ In node Q
 
     Args:
-        inputs: {'I1', 'node_name'}.
+        inputs: {'input_0', 'node_name'}.
         graph: The networkx graph of the circuit.
 
     Returns:
-        Q = I
+        Q = input_0
     """
-    p = validate_inputs(inputs, graph, 'in_node')
-    solver.add_clause([-p['I1'], p['node_name']])
-    solver.add_clause([p['I1'], -p['node_name']])
+    p = validate_generic_inputs(inputs, 2, "in_node_Q")
+    solver.add_clause([-p['input_0'], p['node_name']])
+    solver.add_clause([p['input_0'], -p['node_name']])
 
 
 def in_node_QN(inputs: dict, graph: nx.DiGraph, solver):
     """ In node QN
 
     Args:
-        inputs: {'I1', 'node_name'}.
+        inputs: {'input_0', 'node_name'}.
         graph: The networkx graph of the circuit.
 
     Returns:
-        Q = !I
+        Q = !input_0
     """
-    p = validate_inputs(inputs, graph, 'in_node')
+    p = validate_generic_inputs(inputs, 2, "in_node_QN")
     solver.add_clause([-p['I1'], -p['node_name']])
     solver.add_clause([p['I1'], p['node_name']])
 
@@ -620,30 +645,30 @@ def out_node(inputs: dict, graph: nx.DiGraph, solver):
     """ Out node.
 
     Args:
-        inputs: {'D', 'node_name'}.
+        inputs: {'input_0', 'node_name'}.
         graph: The networkx graph of the circuit.
 
     Returns:
-        ZN = D.
+        ZN = input_0.
     """
-    p = validate_inputs(inputs, graph, 'out_node')
-    solver.add_clause([-p['D'], p['node_name']])
-    solver.add_clause([p['D'], -p['node_name']])
+    p = validate_generic_inputs(inputs, 2, "out_node")
+    solver.add_clause([-p['input_0'], p['node_name']])
+    solver.add_clause([p['input_0'], -p['node_name']])
 
 
 def output(inputs: dict, graph: nx.DiGraph, solver):
     """ Out node.
 
     Args:
-        inputs: {'D', 'node_name'}.
+        inputs: {'input_0', 'node_name'}.
         graph: The networkx graph of the circuit.
 
     Returns:
-        ZN = I.
+        ZN = input_0.
     """
-    p = validate_inputs(inputs, graph, 'output')
-    solver.add_clause([-p['I1'], p['node_name']])
-    solver.add_clause([p['I1'], -p['node_name']])
+    p = validate_generic_inputs(inputs, 2, "output")
+    solver.add_clause([-p['input_0'], p['node_name']])
+    solver.add_clause([p['input_0'], -p['node_name']])
 
 cell_mapping = {
 % for mapping in cell_lib.cell_mapping:


### PR DESCRIPTION
Previously, a DiGraph was used to convert the netlist into a graph.
However, this complicated the construction of the graph, as only single
edges are supported by the graph type. By using MultDiGraph, which 
supports multiple edges (=connection between gates), the code now 
gets simpler.

Signed-off-by: Pascal Nasahl <nasahl@google.com>