### PR TITLE
Limit #FI for artifact evaluation

### DIFF
--- a/examples/ibex/run.sh
+++ b/examples/ibex/run.sh
@@ -36,4 +36,4 @@ $FI_INJECTOR    -p output/netlist_ibex_if_stage.pickle \
 $FI_INJECTOR    -p output/netlist_ibex_if_stage.pickle \
                 -f fault_model_ibex_if_stage_pc_target.json -n $N_CPUS \
                 -c $CELL_LIB --auto_fl \
-                -s 2 2>&1 | tee -a output/fault_model_ibex_if_stage_pc_target.log
+                -s 2 -l 10000 2>&1 | tee -a output/fault_model_ibex_if_stage_pc_target.log


### PR DESCRIPTION
Limit the number of injected faults into the Ibex IF for the artifact evaluation.

Signed-off-by: Pascal Nasahl <pascal.nasahl@iaik.tugraz.at>