### PR TITLE
Update requirements to easily run on MacOS Ventura

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools -U
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools -U
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy==1.24.2
 sympy==1.6.2
 ray==1.8.0
 pathlib==1.0.1
-liberty-parser==0.0.11
+liberty-parser==0.0.16
 python-sat==0.1.8.dev3
 protobuf==3.20.*
 mako==1.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 networkx==2.6.3
-numpy==1.19.5
+numpy==1.24.2
 sympy==1.6.2
-ray==1.7.0
+ray==1.8.0
 pathlib==1.0.1
 liberty-parser==0.0.11
-python-sat==0.1.7.dev14
+python-sat==0.1.8.dev3
 protobuf==3.20.*
+mako==1.2.4


### PR DESCRIPTION
I bumped a few requirements which were outdated and not available for MacOS Ventura.

Added `mako`, which was missing.