### PR TITLE
Update EOL GitHub Actions dependencies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,9 +16,9 @@ jobs:
     timeout-minutes: 5
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies


### PR DESCRIPTION
This PR updates GitHub Actions dependencies using Node v12 which will be [removed on the 14th of August](https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/).

These are:

* [actions/checkout](https://github.com/actions/checkout) from v2 -> v3.
* [actions/setup-python](https://github.com/actions/setup-python/) from v2 -> v4.

I don't see any breaking changes in the major version bumps we should care about, just the upgrade to Node16:

* https://github.com/actions/checkout/releases/tag/v3.0.0
* https://github.com/actions/setup-python/releases/tag/v3.0.0
* https://github.com/actions/setup-python/releases/tag/v4.0.0